### PR TITLE
Error, ACR and forceAuthN UI changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ def start_code_flow():
     """
     :return: redirects to the authorization server with the appropriate parameters set.
     """
-    login_url = _client.get_authn_req_url(session)
+    login_url = _client.get_authn_req_url(session, request.args.get("acr", None), request.args.get("forceAuthN", False))
     return redirect(login_url)
 
 
@@ -139,10 +139,13 @@ def call_api():
                 try:
                     request = urllib2.Request(_config['api_endpoint'])
                     request.add_header("Authorization", "Bearer %s" % user.access_token)
+                    request.add_header("Accept", 'application/jwt, application/json;q=0.9')
                     response = urllib2.urlopen(request)
                     user.api_response = {'code': response.code, 'data': response.read()}
                 except urllib2.HTTPError as e:
                     user.api_response = {'code': e.code, 'data': e.read()}
+                except Exception as e:
+                    user.api_response = {"code": "unknown error", "data": e.message }
             else:
                 user.api_response = None
                 print 'No access token in session'

--- a/app.py
+++ b/app.py
@@ -139,7 +139,7 @@ def call_api():
                 try:
                     request = urllib2.Request(_config['api_endpoint'])
                     request.add_header("Authorization", "Bearer %s" % user.access_token)
-                    request.add_header("Accept", 'application/jwt, application/json;q=0.9')
+                    request.add_header("Accept", 'application/json')
                     response = urllib2.urlopen(request)
                     user.api_response = {'code': response.code, 'data': response.read()}
                 except urllib2.HTTPError as e:

--- a/client.py
+++ b/client.py
@@ -86,7 +86,7 @@ class Client:
         token_response = urllib2.urlopen(self.config['token_endpoint'], urllib.urlencode(data), context=self.ctx)
         return json.loads(token_response.read())
 
-    def get_authn_req_url(self, session):
+    def get_authn_req_url(self, session, acr, forceAuthN):
         """
         :param session: the session, will be used to keep the OAuth state
         :return redirect url for the OAuth code flow
@@ -94,6 +94,8 @@ class Client:
         state = tools.generate_random_string()
         session['state'] = state
         request_args = self.__authn_req_args(state)
+        if acr: request_args["acr"] = acr
+        if forceAuthN: request_args["forceAuthN"] = "true"
         login_url = "%s?%s" % (self.config['authorization_endpoint'], urllib.urlencode(request_args))
         print "Redirect to federation service %s" % login_url
         return login_url

--- a/client.py
+++ b/client.py
@@ -94,8 +94,8 @@ class Client:
         state = tools.generate_random_string()
         session['state'] = state
         request_args = self.__authn_req_args(state)
-        if acr: request_args["acr"] = acr
-        if forceAuthN: request_args["forceAuthN"] = "true"
+        if acr: request_args["acr_values"] = acr
+        if forceAuthN: request_args["prompt"] = "login"
         login_url = "%s?%s" % (self.config['authorization_endpoint'], urllib.urlencode(request_args))
         print "Redirect to federation service %s" % login_url
         return login_url

--- a/templates/index.html
+++ b/templates/index.html
@@ -133,8 +133,7 @@
                 <div class="center-block">
                     <a class="btn btn-primary center-block" style="display: block; width: 200px" role="button" href="/start-login">Sign In</a>
                 </div>
-            {% else %}
-
+            {% elif not error %}
                 <ul class="list-group">
                     {% if session.api_response %}
                         <li class="list-group-item">
@@ -185,19 +184,31 @@
         </div>
         <div class="col-md-3"></div>
     </div>
-    <div class="row">
+    <div class="row" style="margin-bottom: 2em">
         <div class="col-md-3"></div>
         <div class="col-md-6">
             {% if session %}
-                <div class="btn-group btn-group-justified mb" role="group">
-                    <a href="/call-api" class="btn btn-default" type="button">Request data from api</a>
-                </div>
+                {% if not error %}
+                    <div class="btn-group btn-group-justified mb" role="group">
+                        <a href="/call-api" class="btn btn-default" type="button">Request data from api</a>
+                    </div>
+                {%  endif %}
+                <form action="/start-login" method="get">
+                    <div class="form-group">
+                        <input type="text" class="form-control" name="acr" id="acr" placeholder="Authentication class context reference (ACR)">
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" name="forceAuthN">Force authentication</label>
+                    </div>
+                    <div style="margin-bottom: 1em">
+                        <button type="submit" class="btn btn-default btn-group-justified mb">Restart Login</button>
+                    </div>
+                </form>
                 <div class="btn-group btn-group-justified" role="group">
-                    <a class="btn btn-default" type="button" href="/logout">Log out</a>
+                    <a class="btn btn-primary" type="button" href="/logout">Log out</a>
                 </div>
             {% endif %}
         </div>
-        <div class="col-md-3"></div>
     </div>
 </div>
 </body>


### PR DESCRIPTION
This PR provides the ability for the user to restart the OAuth flow without logging in. The user can also specify that reauthenticaton should be forced. A text input has been added to allow the user to specify ACRs. Curity's legacy param names are used instead of OIDC ones; this could be changed if desired to use OIDC ones now that Curity supports that. 

Summary of commit

* change what is shown when there's an error
* add inputs to restart the flow
* request an ACR, and force authentication