### PR TITLE
Fix/master/11 pkce support

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,8 +181,11 @@ def oauth_callback():
     if 'code' not in request.args:
         return create_error('No code in response')
 
+    if "code_verifier" not in session:
+        return create_error("No code_verifier in session")
+
     try:
-        token_data = _client.get_token(request.args['code'])
+        token_data = _client.get_token(request.args['code'], session["code_verifier"])
     except Exception as e:
         return create_error('Could not fetch token(s)', e)
     session.pop('state', None)

--- a/app.py
+++ b/app.py
@@ -200,7 +200,7 @@ def oauth_callback():
             return create_error('Could not validate token: no issuer configured')
 
         try:
-            _jwt_validator.validate(token_data['id_token'], _config['issuer'], _config['client_id'])
+            _jwt_validator.validate(token_data['id_token'], _config['issuer'], _config['audience'])
         except BadSignature as bs:
             return create_error('Could not validate token: %s' % bs.message)
         except Exception as ve:

--- a/app.py
+++ b/app.py
@@ -71,7 +71,13 @@ def start_code_flow():
     """
     :return: redirects to the authorization server with the appropriate parameters set.
     """
-    login_url = _client.get_authn_req_url(session, request.args.get("acr", None), request.args.get("forceAuthN", False))
+    provided_scopes = request.args.get("scope")
+    default_scopes = _client.config['scope']
+    scopes = provided_scopes if provided_scopes else default_scopes
+
+    login_url = _client.get_authn_req_url(session, request.args.get("acr", None),
+                                          request.args.get("forceAuthN", False),
+                                          scopes)
     return redirect(login_url)
 
 

--- a/client.py
+++ b/client.py
@@ -85,14 +85,14 @@ class Client:
         token_response = self.urlopen(self.config['token_endpoint'], urllib.urlencode(data), context=self.ctx)
         return json.loads(token_response.read())
 
-    def get_authn_req_url(self, session, acr, forceAuthN):
+    def get_authn_req_url(self, session, acr, forceAuthN, scope):
         """
         :param session: the session, will be used to keep the OAuth state
         :return redirect url for the OAuth code flow
         """
         state = tools.generate_random_string()
         session['state'] = state
-        request_args = self.__authn_req_args(state)
+        request_args = self.__authn_req_args(state, scope)
         if acr: request_args["acr_values"] = acr
         if forceAuthN: request_args["prompt"] = "login"
         login_url = "%s?%s" % (self.config['authorization_endpoint'], urllib.urlencode(request_args))
@@ -134,12 +134,12 @@ class Client:
         return urllib2.urlopen(request, context=context)
 
 
-    def __authn_req_args(self, state):
+    def __authn_req_args(self, state, scope):
         """
         :param state: state to send to authorization server
         :return a map of arguments to be sent to the authz endpoint
         """
-        args = {'scope': self.config['scope'],
+        args = {'scope': scope,
                 'response_type': 'code',
                 'client_id': self.config['client_id'],
                 'state': state,

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
   "client_id": "client-1",
   "client_secret": "Password1",
+  "audience": "client-one",
   "redirect_uri": "https://localhost:5443/callback",
   "scope": "openid read",
   "authorization_endpoint": "https://nordicapis.curity.io/oauth/v2/authorize",

--- a/templates/index.html
+++ b/templates/index.html
@@ -189,6 +189,9 @@
                     <div class="checkbox">
                         <label><input type="checkbox" name="forceAuthN">Force authentication</label>
                     </div>
+                    <div class="form-group">
+                        <input type="text" class="form-control" value="{{ scope }}" name="scope" id="scope" placeholder="Space-separated list of scopes">
+                    </div>
                     <div style="margin-bottom: 1em">
                         <button type="submit" class="btn btn-default btn-group-justified mb">Restart Login</button>
                     </div>

--- a/tools.py
+++ b/tools.py
@@ -26,6 +26,10 @@ def base64_urldecode(s):
     return base64.urlsafe_b64decode(ascii_string)
 
 
+def base64_urlencode(s):
+    return base64.urlsafe_b64encode(s).split("=")[0].replace('+', '-').replace('/', '_')
+
+
 def decode_token(token):
     """
     Decode a jwt into readable format.

--- a/tools.py
+++ b/tools.py
@@ -42,11 +42,11 @@ def decode_token(token):
     return None
 
 
-def generate_random_string():
+def generate_random_string(size=20):
     """
-    :return: a 20 character random stringmusing only ascii characters and digits
+    :return: a random string with a default size of 20 bytes using only ascii characters and digits
     """
-    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(20))
+    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(size))
 
 
 def get_ssl_context(config):


### PR DESCRIPTION
This PR provides 3 things:

* PKCE support
* Ability to set the scope ruing the authorization flow (for subsequent requests at least, not the first)
* Audience is configured separately and the client ID isn't assumed (helpful for when the client ID is a dynamic client and the audience is the client ID of the template on which that client is based)