### PR TITLE
Added missing audience key

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,6 +29,7 @@ class Config():
             'disable_https',
             'discovery_url',
             'issuer',
+            'audience',
             'jwks_uri',
             'logout_endpoint',
             'port',


### PR DESCRIPTION
Will not load audience configuration from enviroment variables since the key is missing.