### PR TITLE
allow client to force consent when restarting flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,7 +77,8 @@ def start_code_flow():
 
     login_url = _client.get_authn_req_url(session, request.args.get("acr", None),
                                           request.args.get("forceAuthN", False),
-                                          scopes)
+                                          scopes, request.args.get("forceConsent", False),
+                                          request.args.get("allowConsentOptionDeselection", False))
     return redirect(login_url)
 
 

--- a/client.py
+++ b/client.py
@@ -86,7 +86,7 @@ class Client:
         token_response = self.urlopen(self.config['token_endpoint'], urllib.urlencode(data), context=self.ctx)
         return json.loads(token_response.read())
 
-    def get_authn_req_url(self, session, acr, forceAuthN, scope):
+    def get_authn_req_url(self, session, acr, forceAuthN, scope, forceConsent, allowConsentOptionDeselection):
         """
         :param session: the session, will be used to keep the OAuth state
         :return redirect url for the OAuth code flow
@@ -100,6 +100,13 @@ class Client:
         request_args = self.__authn_req_args(state, scope, code_challenge, "S256")
         if acr: request_args["acr_values"] = acr
         if forceAuthN: request_args["prompt"] = "login"
+
+        if forceConsent:
+            if allowConsentOptionDeselection:
+                request_args["prompt"] = request_args.get("prompt", "") + " consent consent_allow_deselection"
+            else:
+                request_args["prompt"] = request_args.get("prompt", "") + " consent"
+
         delimiter = "?" if self.config['authorization_endpoint'].find("?") < 0 else "&"
         login_url = "%s%s%s" % (self.config['authorization_endpoint'], delimiter, urllib.urlencode(request_args))
         print "Redirect to federation service %s" % login_url

--- a/templates/index.html
+++ b/templates/index.html
@@ -190,6 +190,12 @@
                     <div class="checkbox">
                         <label><input type="checkbox" name="forceAuthN">Force authentication</label>
                     </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" name="forceConsent">Force consent</label>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" name="allowConsentOptionDeselection" checked>Allow deselection of consent options</label>
+                    </div>
                     <div class="form-group">
                         <input type="text" class="form-control" value="{{ scope }}" name="scope" id="scope" placeholder="Space-separated list of scopes">
                     </div>


### PR DESCRIPTION
This PR adds a prompt that allows the authorization request to be restarted with consent being forced. This is done using `prompt=consent`.

<img width="521" alt="screen shot 2018-09-04 at 8 53 36 pm" src="https://user-images.githubusercontent.com/2499235/45051780-551e7b00-b085-11e8-8b2f-a2ea80f6c59e.png">
