### PR TITLE
Fix for docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ ADD requirements.txt /usr/src/
 RUN pip install --no-cache-dir -r /usr/src/requirements.txt
 WORKDIR /oidc-example
 EXPOSE 5443
-VOLUME /oidc-example/settings.json
-
 
 RUN mkdir -p /oidc-example
 ADD keys /oidc-example/keys
@@ -31,3 +29,4 @@ RUN echo "{}" >> /oidc-example/settings.json
 ADD *.py /oidc-example/
 
 CMD ["python", "app.py"]
+

--- a/app.py
+++ b/app.py
@@ -425,16 +425,6 @@ if __name__ == '__main__':
     # some default values
     if 'port' in _config:
         port = _config['port']
-    elif "base_url" in _config:
-        parse_result = urlparse(_config['base_url'])
-        _config['base_url'] = _config['base_url'].rstrip('/')
-
-        if not parse_result.port:
-            port = parse_result.port
-        elif parse_result.scheme == "https":
-            port = 443
-        else:
-            port = 80
     else:
         port = 5443
 

--- a/app.py
+++ b/app.py
@@ -424,7 +424,7 @@ if __name__ == '__main__':
 
     # some default values
     if 'port' in _config:
-        port = _config['port']
+        port = int(_config['port'])
     else:
         port = 5443
 


### PR DESCRIPTION
Small fixes discovered when building the new docker container
* We cannot derive the port to run on, since we might be running in a docker container with port mapping
* Remove the Volume for settings.json, so we can create an empty file
* If port config is coming from env variable, port is a string